### PR TITLE
fix 5G-MAG/rt-xr-unity-player#28

### DIFF
--- a/addons/io_scene_gltf2_mpeg/com/MPEG_audio_spatial.py
+++ b/addons/io_scene_gltf2_mpeg/com/MPEG_audio_spatial.py
@@ -194,10 +194,10 @@ class MPEGAudioSpatialReverb:
 class Attenuation(Enum):
     """A function used to calculate the attenuation of the audio source."""
     custom = "custom"
-    exponentialDistance = "exponential_distance"
-    inverseDistance = "inverse_distance"
-    linearDistance = "linear_distance"
-    noAttenuation = "no_attenuation"
+    exponentialDistance = "exponentialDistance"
+    inverseDistance = "inverseDistance"
+    linearDistance = "linearDistance"
+    noAttenuation = "noAttenuation"
 
 
 class TypeEnum(Enum):


### PR DESCRIPTION
Change audio attenuation function names from *snake_case* to *camelCase*. 