### PR TITLE
Initial support for XR Anchoring

### DIFF
--- a/addons/io_scene_gltf2_mpeg/__init__.py
+++ b/addons/io_scene_gltf2_mpeg/__init__.py
@@ -12,8 +12,12 @@ import importlib
 import inspect
 import pkgutil
 from pathlib import Path
+from .blender.ui.anchoring import register_xr_anchors, unregister_xr_anchors
 
 import bpy
+import logging
+
+log = logging.getLogger(__name__)
 
 bl_info = {
     "name": "rt-xr-blender-exporter",
@@ -56,6 +60,7 @@ class MPEG_ExporterProperties(bpy.types.PropertyGroup):
         default=True,
     )
 
+    # TODO: autodetect & use manual config to force re-encoding
     audio_object_codec: bpy.props.EnumProperty(
         items= [
             ('MP3', "mp3", ""),
@@ -98,11 +103,13 @@ class GLTF_PT_MPEGExporterExtensionPanel(bpy.types.Panel):
 
 
 def register():
+    register_xr_anchors()
     bpy.utils.register_class(MPEG_ExporterProperties)
     bpy.types.Scene.MPEG_ExporterProperties = bpy.props.PointerProperty(type=MPEG_ExporterProperties)
 
 
 def unregister():
+    unregister_xr_anchors()
     unregister_panel()
     bpy.utils.unregister_class(MPEG_ExporterProperties)
     del bpy.types.Scene.MPEG_ExporterProperties

--- a/addons/io_scene_gltf2_mpeg/__init__.py
+++ b/addons/io_scene_gltf2_mpeg/__init__.py
@@ -103,6 +103,7 @@ class GLTF_PT_MPEGExporterExtensionPanel(bpy.types.Panel):
 
 
 def register():
+    register_panel()
     register_xr_anchors()
     bpy.utils.register_class(MPEG_ExporterProperties)
     bpy.types.Scene.MPEG_ExporterProperties = bpy.props.PointerProperty(type=MPEG_ExporterProperties)

--- a/addons/io_scene_gltf2_mpeg/blender/ui/anchoring.py
+++ b/addons/io_scene_gltf2_mpeg/blender/ui/anchoring.py
@@ -1,5 +1,4 @@
 import bpy
-import logging
 from .markers import register_markers, unregister_markers, XRMarkerFactory
 
 ANCHORABLE_TYPES = (

--- a/addons/io_scene_gltf2_mpeg/blender/ui/anchoring.py
+++ b/addons/io_scene_gltf2_mpeg/blender/ui/anchoring.py
@@ -1,10 +1,5 @@
 import bpy
 
-################################################################################################
-# MPEG_anchor model
-    ################################################################################################
-
-# List of anchoring types for the dropdown
 XR_TRACKABLE_TYPES = [
     ('TRACKABLE_FLOOR', "Floor", "Anchor to the floor"),
     ('TRACKABLE_VIEWER', "Viewer", "Anchor to the viewer (1st person)"),
@@ -21,293 +16,40 @@ TRACKABLE_GEOMETRIC_CONSTRAINT = [
     ('VERTICAL_PLANE', 'Vertical', 'Vertical')
 ]
 
-
-def update_trackable_type(self, context):
-    # Find and assign the trackable from scene.xr_trackables by name
-    name = '_'.join(self.type.split('_')[0:]).lower()
-    if not self.type in ('TRACKABLE_FLOOR', 'TRACKABLE_VIEWER'):
-        count = 0
-        for trackable in context.scene.xr_trackables:
-            if trackable.type == self.type:
-                count +=1
-        name = f'{name}_{count}'
-    self.name = name
-    
-class XRTrackableObjectProperty(bpy.types.PropertyGroup):
-
-    type: bpy.props.EnumProperty(items=XR_TRACKABLE_TYPES, update=update_trackable_type)
-
-    # TRACKABLE_FLOOR
-    # TRACKABLE_VIEWER
-    # - no additional properties -
-
-    # TRACKABLE_CONTROLLER
-    path: bpy.props.StringProperty(
-        name="Path", 
-        description="A path that describes the action space as specified by the OpenXR specification in clause 6.2. An example is '/user/hand/left/input'."
-    )
-
-    # TRACKABLE_GEOMETRIC
-    geometricConstraint: bpy.props.EnumProperty(items=TRACKABLE_GEOMETRIC_CONSTRAINT)
-
-    # TRACKABLE_MARKER_2D
-    # TRACKABLE_MARKER_3D
-    marker_2D: bpy.props.PointerProperty(
-        type=bpy.types.Image,
-        name="2D marker",
-        description="Select an anchor image"
-    )
-
-    # TRACKABLE_MARKER_GEO
-    coordinates: bpy.props.FloatVectorProperty(name="longitude[-180.0:180.0], latitude[-90.0:90.0], elevation[meters above the WGS 84 reference ellipsoid]")
-
-
-def update_anchor_trackable(self, context):
-    # Find and assign the trackable from scene.xr_trackables by name
-    scene = context.scene
-    for trackable in scene.xr_trackables:
-        if trackable.name == self.trackable_name:
-            self.trackable = trackable
-            break
+ANCHOR_ALIGNMENT = [
+    ('NOT_USED', 'Not used', 'Not used'),
+    ('ALIGNED_NOTSCALED', 'Not scale', 'Not scaled'),
+    ('ALIGNED_SCALED', 'Scaled', 'Scaled')
+]
 
 class XRAnchorObjectProperties(bpy.types.PropertyGroup):
-    # Mandatory
-    trackable_name: bpy.props.StringProperty(name="Trackable Name", update=update_anchor_trackable)
-    trackable: bpy.props.PointerProperty(
-        type=XRTrackableObjectProperty,
-        name="trackable",
-        description="Select a trackable item"
+    enabled: bpy.props.BoolProperty()
+    #############################################
+    # TRACKABLE OBJECT PROPERTIES
+    trackable_type: bpy.props.EnumProperty(items=XR_TRACKABLE_TYPES)
+    trackable_controller: bpy.props.StringProperty(
+        name="Path"
     )
+    trackable_plane: bpy.props.EnumProperty(items=TRACKABLE_GEOMETRIC_CONSTRAINT)
+    trackable_marker_2D: bpy.props.PointerProperty(
+        type=bpy.types.Image,
+        name="2D marker"
+    )
+    trackable_marker_geo: bpy.props.FloatVectorProperty(name="Geo coords")
+    #############################################
+    # ANCHOR OBJECT PROPERTIES
     requiresAnchoring: bpy.props.BoolProperty(name="Requires anchoring")
     minimumRequiredSpace: bpy.props.FloatVectorProperty(name="Min required space")
     aligned: bpy.props.BoolProperty(name="Aligned")
 
-    # https://docs.blender.org/api/current/bpy.props.html#bpy.props.CollectionProperty
-    # actions: bpy.props.CollectionProperty(InteractivityActionsObjectProperty)
-    
-    # MPEG_lights_texture_based
-    # light: bpy.props.PointerProperty(type=MPEGLightTextureProperty)
-    
 
 
-################################################################################################
-# Trackable / Anchor list management
-################################################################################################
-
-class XR_TRACKABLE_UL_List(bpy.types.UIList): 
-    
-    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index): 
-        # We could write some code to decide which icon to use here... 
-        custom_icon = 'OBJECT_DATAMODE' # Make sure your code supports all 3 layout types 
-        if self.layout_type in {'DEFAULT', 'COMPACT'}: 
-            layout.label(text=item.name, icon = custom_icon) 
-        elif self.layout_type in {'GRID'}: 
-            layout.alignment = 'CENTER' 
-            layout.label(text="", icon = custom_icon)
-
-
-class LIST_OT_NewXrTrackable(bpy.types.Operator): 
-    bl_idname = "xr_trackables.new_item" 
-    bl_label = "Add XR trackable"
-
-    def execute(self, context): 
-        context.scene.xr_trackables.add()
-        return{'FINISHED'}
-
-
-class LIST_OT_DeleteXrTrackable(bpy.types.Operator):
-    bl_idname = "xr_trackables.delete_item"
-    bl_label = "Delete XR trackable"
-
-    @classmethod
-    def poll(cls, context):
-        return context.scene.xr_trackables
-
-    def execute(self, context):
-        xr_trackables = context.scene.xr_trackables
-        idx = context.scene.xr_trackable_idx
-        xr_trackables.remove(idx)
-        context.scene.xr_trackable_idx = min(max(0, idx-1), len(xr_trackables)-1)
-        return{'FINISHED'}
-
-
-class XR_OT_set_trackable_type(bpy.types.Operator):
-    bl_idname = "xr_trackable.set_type"
-    bl_label = "Set trackable type"
-    bl_description = "Set type for the selected trackable"
-    type: bpy.props.EnumProperty(items=XR_TRACKABLE_TYPES)
-
-    def execute(self, context):
-        scene = context.scene
-        idx = context.scene.xr_trackable_idx
-        trackable = context.scene.xr_trackables[idx]
-        if trackable is None:
-            self.report({'WARNING'}, "No active object selected.")
-            return {'CANCELLED'}
-        
-        trackable.type = self.type
-        return {'FINISHED'}
-    
-    """
-class LIST_OT_MoveXrTrackable(bpy.types.Operator): 
-    bl_idname = "xr_trackables.move_item" 
-    bl_label = "Move XR trackable" 
-    direction: bpy.props.EnumProperty(items=(('UP', 'Up', ""), ('DOWN', 'Down', ""),)) 
-    
-    @classmethod 
-    def poll(cls, context): 
-        return context.scene.xr_trackables 
-    
-    def move_index(self): 
-        index = bpy.context.scene.xr_trackable_idx 
-        list_length = len(bpy.context.scene.xr_trackables) - 1 # (index starts at 0) 
-        new_index = index + (-1 if self.direction == 'UP' else 1) 
-        bpy.context.scene.xr_trackable_idx = max(0, min(new_index, list_length)) 
-        
-    def execute(self, context): 
-        xr_trackables = context.scene.xr_trackables 
-        index = context.scene.xr_trackable_idx 
-        neighbor = index + (-1 if self.direction == 'UP' else 1) 
-        xr_trackables.move(neighbor, index) 
-        self.move_index() 
-        return{'FINISHED'}
-    """
-
-
-################################################################################################
-
-class XR_ANCHOR_UL_List(bpy.types.UIList): 
-    
-    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index): 
-        # We could write some code to decide which icon to use here... 
-        custom_icon = 'OBJECT_DATAMODE' # Make sure your code supports all 3 layout types 
-        if self.layout_type in {'DEFAULT', 'COMPACT'}: 
-            layout.label(text=item.name, icon = custom_icon) 
-        elif self.layout_type in {'GRID'}: 
-            layout.alignment = 'CENTER' 
-            layout.label(text="", icon = custom_icon)
-
-
-
-class LIST_OT_NewXrAnchor(bpy.types.Operator): 
-    bl_idname = "xr_anchors.new_item" 
-    bl_label = "Add XR anchor"
-
-    def execute(self, context): 
-        context.scene.xr_anchors.add()
-        return{'FINISHED'}
-
-
-class LIST_OT_DeleteXrAnchor(bpy.types.Operator):
-    bl_idname = "xr_anchors.delete_item"
-    bl_label = "Delete XR anchor"
-
-    @classmethod
-    def poll(cls, context):
-        return context.scene.xr_anchors
-
-    def execute(self, context):
-        xr_anchors = context.scene.xr_anchors
-        idx = context.scene.xr_anchor_idx
-        xr_anchors.remove(idx)
-        context.scene.xr_anchor_idx = min(max(0, idx-1), len(xr_anchors)-1)
-        return{'FINISHED'}
-        
-
-class RTXR_PT_anchors_panel(bpy.types.Panel):
-    """
-    Show all anchors. In 3D View, Press N to toggle tabs overlay (top right corner).
-    """
-    bl_label = "XR Anchors"
-    bl_idname = "RTXR_PT_anchors_panel"
-    bl_category = "XR Anchors"
-    bl_space_type = "VIEW_3D"
-    bl_region_type = "UI"
-    #  ('DEFAULT_CLOSED', 'HIDE_HEADER', 'INSTANCED', 'HEADER_LAYOUT_EXPAND')
-    bl_options = {"DEFAULT_CLOSED"}
-
-    def draw(self, context):
-        layout = self.layout 
-        scene = context.scene 
-        
-        row = layout.row()         
-        row.label(text="Scene TRACKABLES:")
-        row = layout.row() 
-        row.template_list("XR_TRACKABLE_UL_List", "XR_trackables_list", scene, "xr_trackables", scene, "xr_trackable_idx") 
-        row = layout.row() 
-        row.operator('xr_trackables.new_item', text='NEW') 
-        row.operator('xr_trackables.delete_item', text='REMOVE') 
-        # row.operator('xr_trackables.move_item', text='UP').direction = 'UP' 
-        # row.operator('xr_trackables.move_item', text='DOWN').direction = 'DOWN' 
-        
-        if scene.xr_trackable_idx >= 0 and scene.xr_trackables: 
-            active_trackable = scene.xr_trackables[scene.xr_trackable_idx] 
-            row = layout.row()
-            row.operator_menu_enum("xr_trackable.set_type", "type", text=active_trackable.type)
-            if active_trackable.type == 'TRACKABLE_FLOOR':
-                pass
-            elif active_trackable.type == 'TRACKABLE_VIEWER':
-                pass
-            elif active_trackable.type == 'TRACKABLE_CONTROLLER':
-                row = layout.row()
-                row.prop(active_trackable, "path") 
-            elif active_trackable.type == 'TRACKABLE_PLANE':
-                row = layout.row()
-                row.prop(active_trackable, "geometricConstraint") 
-            elif active_trackable.type == 'TRACKABLE_MARKER_2D':
-                row = layout.row()
-                row.prop(active_trackable, "name") 
-                row = layout.row()
-                row.prop(active_trackable, "marker_2D")
-                # row.template_ID(active_trackable, "marker_2D", new="image.new", open="image.open")
-            elif active_trackable.type == 'TRACKABLE_MARKER_GEO':
-                row = layout.row()
-                row.prop(active_trackable, "name") 
-                row = layout.row()
-                row.prop(active_trackable, "coordinates")
-            else:
-                row = layout.row()
-                row.label(text="request this feature on github")
-
-        row = layout.row()         
-        row.label(text="Scene ANCHOR:")
-        row = layout.row() 
-        row.template_list("XR_ANCHOR_UL_List", "XR_anchors_list", scene, "xr_anchors", scene, "xr_anchor_idx") 
-        row = layout.row() 
-        row.operator('xr_anchors.new_item', text='NEW') 
-        row.operator('xr_anchors.delete_item', text='REMOVE') 
-        # row.operator('xr_anchors.move_item', text='UP').direction = 'UP' 
-        # row.operator('xr_anchors.move_item', text='DOWN').direction = 'DOWN' 
-        
-        if scene.xr_anchor_idx >= 0 and scene.xr_anchors: 
-            active_anchor = scene.xr_anchors[scene.xr_anchor_idx] 
-            row = layout.row()
-            row.prop(active_anchor, 'name')
-            row = layout.row()
-            row.prop_search(active_anchor, 'trackable_name', scene, 'xr_trackables', icon='OBJECT_DATA')
-            row = layout.row()
-            row.label(text=active_anchor.trackable_name)
-            row = layout.row()
-            row.label(text=active_anchor.trackable.name)
-            row = layout.row()
-            row.prop(active_anchor, 'requiresAnchoring')
-            row = layout.row()
-            row.prop(active_anchor, 'minimumRequiredSpace')
-            row = layout.row()
-            row.prop(active_anchor, 'aligned')
-
-
-################################################################################################
-# Node anchor selection
-################################################################################################
-
-    """
 class OBJECT_OT_set_xr_anchor_type(bpy.types.Operator):
     bl_idname = "object.set_xr_anchor_type"
     bl_label = "Set Anchoring Type"
     bl_description = "Set the anchoring type for the selected object"
 
-    anchor_type: bpy.props.EnumProperty(items=XR_TRACKABLE_TYPES)
+    trackable_type: bpy.props.EnumProperty(items=XR_TRACKABLE_TYPES)
 
     def execute(self, context):
         obj = context.object
@@ -315,87 +57,57 @@ class OBJECT_OT_set_xr_anchor_type(bpy.types.Operator):
             self.report({'WARNING'}, "No active object selected.")
             return {'CANCELLED'}
         
-        obj.xr_anchor.anchor_type = self.anchor_type
+        obj.xr_anchor.trackable_type = self.trackable_type
         return {'FINISHED'}
-    """
 
 
-    """
 class OBJECT_PT_xr_anchor_panel(bpy.types.Panel):
     bl_label = "XR anchoring"
     bl_idname = "OBJECT_PT_xr_anchor_panel"
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
     bl_context = 'object'
-
+    
     def draw(self, context):
         layout = self.layout
         obj = context.object
         if obj is None:
             layout.label(text="No active object selected.")
         else:
-            xr_anchor = obj.xr_anchor # get('anchor_type', 'NONE')
+            xr_anchor = obj.xr_anchor
             row = layout.row()
-            row.operator_menu_enum("object.set_xr_anchor_type", "anchor_type", text=xr_anchor.anchor_type)
-
-            anchor_row = layout.row()
-            anchor_row.label(text='not available')
-
-            if xr_anchor.anchor_type == '2D_MARKER':
-                layout.template_ID(obj.xr_anchor, "marker_2D", new="image.new", open="image.open")
-    """
+            row.prop(xr_anchor, "enabled") 
+            if not xr_anchor.enabled:
+                return
+            row = layout.row()
+            row.operator_menu_enum("object.set_xr_anchor_type", "trackable_type", text=xr_anchor.trackable_type)
+            if xr_anchor.trackable_type == 'TRACKABLE_CONTROLLER':
+                row = layout.row()
+                row.prop(xr_anchor, "trackable_controller") 
+            elif xr_anchor.trackable_type == 'TRACKABLE_PLANE':
+                row = layout.row()
+                row.prop(xr_anchor, "trackable_plane") 
+            elif xr_anchor.trackable_type == 'TRACKABLE_MARKER_2D':
+                row = layout.row()
+                row.prop(xr_anchor, "trackable_marker_2D")
+                # row.template_ID(xr_anchor, "marker_2D", new="image.new", open="image.open")
+            elif xr_anchor.trackable_type == 'TRACKABLE_MARKER_GEO':
+                row = layout.row()
+                row.prop(xr_anchor, "trackable_marker_geo")
+            elif xr_anchor.trackable_type == 'TRACKABLE_MARKER_3D' or \
+                    xr_anchor.trackable_type == 'TRACKABLE_MARKER_APPLICATION':
+                row = layout.row()
+                row.label(text="request this feature on github")
 
 
 def register_xr_anchors():
-    # Scene level ANCHOR def 
-    bpy.utils.register_class(XRTrackableObjectProperty)
-    bpy.types.Scene.xr_trackables = bpy.props.CollectionProperty(type=XRTrackableObjectProperty)
-    bpy.types.Scene.xr_trackable_idx = bpy.props.IntProperty(name = "Selected trackable", default = 0)
-    bpy.utils.register_class(XR_TRACKABLE_UL_List) 
-    bpy.utils.register_class(LIST_OT_NewXrTrackable) 
-    bpy.utils.register_class(LIST_OT_DeleteXrTrackable) 
-    # bpy.utils.register_class(LIST_OT_MoveXrTrackable)
-    bpy.utils.register_class(XR_OT_set_trackable_type)
-
-    # Scene level ANCHOR def 
     bpy.utils.register_class(XRAnchorObjectProperties)
-    bpy.types.Scene.xr_anchors = bpy.props.CollectionProperty(type=XRAnchorObjectProperties)
-    bpy.types.Scene.xr_anchor_idx = bpy.props.IntProperty(name = "Selected anchor", default = 0)
-    bpy.utils.register_class(XR_ANCHOR_UL_List) 
-    bpy.utils.register_class(LIST_OT_NewXrAnchor) 
-    bpy.utils.register_class(LIST_OT_DeleteXrAnchor) 
-    # bpy.utils.register_class(LIST_OT_MoveXrAnchor)
-
-    # Node configuration
-    # bpy.types.Object.xr_anchor = bpy.props.PointerProperty(type=XRAnchorObjectProperties)
-    # bpy.utils.register_class(OBJECT_OT_set_xr_anchor_type)
-    # bpy.utils.register_class(OBJECT_PT_xr_anchor_panel)
-
-    # Scene configuration
-    bpy.utils.register_class(RTXR_PT_anchors_panel)
-
+    bpy.types.Object.xr_anchor = bpy.props.PointerProperty(type=XRAnchorObjectProperties)
+    bpy.utils.register_class(OBJECT_OT_set_xr_anchor_type)
+    bpy.utils.register_class(OBJECT_PT_xr_anchor_panel)
 
 def unregister_xr_anchors():
-    bpy.utils.unregister_class(RTXR_PT_anchors_panel)
-    # Scene level anchor def
-    bpy.utils.unregister_class(LIST_OT_NewXrTrackable) 
-    bpy.utils.unregister_class(LIST_OT_DeleteXrTrackable) 
-    # bpy.utils.unregister_class(LIST_OT_MoveXrTrackable)
-    bpy.utils.unregister_class(XR_OT_set_trackable_type)
-    bpy.utils.unregister_class(XR_TRACKABLE_UL_List)    
-    del bpy.types.Scene.xr_trackables
-    del bpy.types.Scene.xr_trackable_idx
-
-    bpy.utils.unregister_class(LIST_OT_NewXrAnchor) 
-    bpy.utils.unregister_class(LIST_OT_DeleteXrAnchor) 
-    # bpy.utils.unregister_class(LIST_OT_MoveXrAnchor)
-    bpy.utils.unregister_class(XR_ANCHOR_UL_List) 
-    del bpy.types.Scene.xr_anchors
-    del bpy.types.Scene.xr_anchor_idx
-    # Node level anchor ref
-    # bpy.utils.unregister_class(OBJECT_OT_set_xr_anchor_type)
-    # bpy.utils.unregister_class(OBJECT_PT_xr_anchor_panel)
-    # del bpy.types.Object.xr_anchor
-    # Anchor model 
+    bpy.utils.unregister_class(OBJECT_PT_xr_anchor_panel)
+    bpy.utils.unregister_class(OBJECT_OT_set_xr_anchor_type)
     bpy.utils.unregister_class(XRAnchorObjectProperties)
-    bpy.utils.unregister_class(XRTrackableObjectProperty)
+    del bpy.types.Object.xr_anchor

--- a/addons/io_scene_gltf2_mpeg/blender/ui/anchoring.py
+++ b/addons/io_scene_gltf2_mpeg/blender/ui/anchoring.py
@@ -45,7 +45,7 @@ class XRAnchorObjectProperties(bpy.types.PropertyGroup):
     trackable_type: bpy.props.EnumProperty(items=XR_TRACKABLE_TYPES)
     trackable_controller: bpy.props.StringProperty(name="XrPath")
     trackable_plane: bpy.props.EnumProperty(items=TRACKABLE_GEOMETRIC_CONSTRAINT)
-    trackable_marker_2d: bpy.props.EnumProperty(items=xr_marker_2d_list)
+    trackable_marker_node: bpy.props.EnumProperty(items=xr_marker_2d_list)
     trackable_marker_geo: bpy.props.FloatVectorProperty(name="Geo coords")
     trackable_id: bpy.props.StringProperty(name="Custom ID")
     #############################################
@@ -76,14 +76,14 @@ class XRAnchor_OT_SelectXrMarker2d(bpy.types.Operator):
     bl_label = "Marker"
     bl_description = "Select a 2D marker"
 
-    trackable_marker_2d: bpy.props.EnumProperty(items=xr_marker_2d_list)
+    trackable_marker_node: bpy.props.EnumProperty(items=xr_marker_2d_list)
 
     def execute(self, context):
         obj = context.object
         if obj is None:
             self.report({'WARNING'}, "No active object selected.")
             return {'CANCELLED'}
-        obj.xr_anchor.trackable_marker_2d = self.trackable_marker_2d
+        obj.xr_anchor.trackable_marker_node = self.trackable_marker_node
         return {'FINISHED'}
 
 
@@ -123,7 +123,7 @@ class XrAnchorObjectPropertiesPanel(bpy.types.Panel):
             elif xr_anchor.trackable_type == 'TRACKABLE_MARKER_2D':
                 row = layout.row()
                 if XRMarkerFactory.scene_has_markers():
-                    row.operator_menu_enum("object.select_xr_marker_2d", "xr_marker_id", text=xr_anchor.trackable_marker_2d)
+                    row.operator_menu_enum("object.select_xr_marker_2d", "xr_marker_id", text=xr_anchor.trackable_marker_node)
                 else:
                     # TODO: set focus on the panel for users to create anchor
                     row.label(text='no XR marker found')

--- a/addons/io_scene_gltf2_mpeg/blender/ui/anchoring.py
+++ b/addons/io_scene_gltf2_mpeg/blender/ui/anchoring.py
@@ -33,7 +33,7 @@ ANCHOR_ALIGNMENT = [
     ('ALIGNED_SCALED', 'Scaled', 'Scaled')
 ]
 
-def xr_marker_2d_list(struct, context):
+def xr_marker_2d_list_names(struct, context):
     return ((obj.xr_marker.name, obj.xr_marker.name, str(obj)) for obj in XRMarkerFactory.iter_xr_marker_objects())
 
 
@@ -44,7 +44,7 @@ class XRAnchorObjectProperties(bpy.types.PropertyGroup):
     trackable_type: bpy.props.EnumProperty(items=XR_TRACKABLE_TYPES)
     trackable_controller: bpy.props.StringProperty(name="XrPath")
     trackable_plane: bpy.props.EnumProperty(items=TRACKABLE_GEOMETRIC_CONSTRAINT)
-    trackable_marker_node: bpy.props.EnumProperty(items=xr_marker_2d_list)
+    trackable_marker_node_name: bpy.props.EnumProperty(items=xr_marker_2d_list_names)
     trackable_marker_geo: bpy.props.FloatVectorProperty(name="Geo coords")
     trackable_id: bpy.props.StringProperty(name="Custom ID")
     #############################################
@@ -75,14 +75,14 @@ class XRAnchor_OT_SelectXrMarker2d(bpy.types.Operator):
     bl_label = "Marker"
     bl_description = "Select a 2D marker"
 
-    trackable_marker_node: bpy.props.EnumProperty(items=xr_marker_2d_list)
+    trackable_marker_node_name: bpy.props.EnumProperty(items=xr_marker_2d_list_names)
 
     def execute(self, context):
         obj = context.object
         if obj is None:
             self.report({'WARNING'}, "No active object selected.")
             return {'CANCELLED'}
-        obj.xr_anchor.trackable_marker_node = self.trackable_marker_node
+        obj.xr_anchor.trackable_marker_node_name = self.trackable_marker_node_name
         return {'FINISHED'}
 
 
@@ -122,7 +122,7 @@ class XrAnchorObjectPropertiesPanel(bpy.types.Panel):
             elif xr_anchor.trackable_type == 'TRACKABLE_MARKER_2D':
                 row = layout.row()
                 if XRMarkerFactory.scene_has_markers():
-                    row.operator_menu_enum("object.select_xr_marker_2d", "xr_marker_id", text=xr_anchor.trackable_marker_node)
+                    row.operator_menu_enum("object.select_xr_marker_2d", "xr_marker_id", text=xr_anchor.trackable_marker_node_name)
                 else:
                     # TODO: set focus on the panel for users to create anchor
                     row.label(text='no XR marker found')

--- a/addons/io_scene_gltf2_mpeg/blender/ui/anchoring.py
+++ b/addons/io_scene_gltf2_mpeg/blender/ui/anchoring.py
@@ -1,0 +1,401 @@
+import bpy
+
+################################################################################################
+# MPEG_anchor model
+    ################################################################################################
+
+# List of anchoring types for the dropdown
+XR_TRACKABLE_TYPES = [
+    ('TRACKABLE_FLOOR', "Floor", "Anchor to the floor"),
+    ('TRACKABLE_VIEWER', "Viewer", "Anchor to the viewer (1st person)"),
+    ('TRACKABLE_CONTROLLER', 'Controller', 'Anchor to the controller path'),
+    ('TRACKABLE_PLANE', "Plane", "Anchor to a plane"),
+    ('TRACKABLE_MARKER_2D', "2D Marker", "Anchor to a 2D marker"),
+    ('TRACKABLE_MARKER_3D', "3D Marker", "Anchor to a 3D marker"),
+    ('TRACKABLE_MARKER_GEO', "GeoCoord", "Anchor using geographic coordinates"),
+    ('TRACKABLE_APPLICATION', "Application", "Application specific")
+]
+
+TRACKABLE_GEOMETRIC_CONSTRAINT = [
+    ('HORIZONTAL_PLANE', 'Horizontal', 'Horizontal'),
+    ('VERTICAL_PLANE', 'Vertical', 'Vertical')
+]
+
+
+def update_trackable_type(self, context):
+    # Find and assign the trackable from scene.xr_trackables by name
+    name = '_'.join(self.type.split('_')[0:]).lower()
+    if not self.type in ('TRACKABLE_FLOOR', 'TRACKABLE_VIEWER'):
+        count = 0
+        for trackable in context.scene.xr_trackables:
+            if trackable.type == self.type:
+                count +=1
+        name = f'{name}_{count}'
+    self.name = name
+    
+class XRTrackableObjectProperty(bpy.types.PropertyGroup):
+
+    type: bpy.props.EnumProperty(items=XR_TRACKABLE_TYPES, update=update_trackable_type)
+
+    # TRACKABLE_FLOOR
+    # TRACKABLE_VIEWER
+    # - no additional properties -
+
+    # TRACKABLE_CONTROLLER
+    path: bpy.props.StringProperty(
+        name="Path", 
+        description="A path that describes the action space as specified by the OpenXR specification in clause 6.2. An example is '/user/hand/left/input'."
+    )
+
+    # TRACKABLE_GEOMETRIC
+    geometricConstraint: bpy.props.EnumProperty(items=TRACKABLE_GEOMETRIC_CONSTRAINT)
+
+    # TRACKABLE_MARKER_2D
+    # TRACKABLE_MARKER_3D
+    marker_2D: bpy.props.PointerProperty(
+        type=bpy.types.Image,
+        name="2D marker",
+        description="Select an anchor image"
+    )
+
+    # TRACKABLE_MARKER_GEO
+    coordinates: bpy.props.FloatVectorProperty(name="longitude[-180.0:180.0], latitude[-90.0:90.0], elevation[meters above the WGS 84 reference ellipsoid]")
+
+
+def update_anchor_trackable(self, context):
+    # Find and assign the trackable from scene.xr_trackables by name
+    scene = context.scene
+    for trackable in scene.xr_trackables:
+        if trackable.name == self.trackable_name:
+            self.trackable = trackable
+            break
+
+class XRAnchorObjectProperties(bpy.types.PropertyGroup):
+    # Mandatory
+    trackable_name: bpy.props.StringProperty(name="Trackable Name", update=update_anchor_trackable)
+    trackable: bpy.props.PointerProperty(
+        type=XRTrackableObjectProperty,
+        name="trackable",
+        description="Select a trackable item"
+    )
+    requiresAnchoring: bpy.props.BoolProperty(name="Requires anchoring")
+    minimumRequiredSpace: bpy.props.FloatVectorProperty(name="Min required space")
+    aligned: bpy.props.BoolProperty(name="Aligned")
+
+    # https://docs.blender.org/api/current/bpy.props.html#bpy.props.CollectionProperty
+    # actions: bpy.props.CollectionProperty(InteractivityActionsObjectProperty)
+    
+    # MPEG_lights_texture_based
+    # light: bpy.props.PointerProperty(type=MPEGLightTextureProperty)
+    
+
+
+################################################################################################
+# Trackable / Anchor list management
+################################################################################################
+
+class XR_TRACKABLE_UL_List(bpy.types.UIList): 
+    
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index): 
+        # We could write some code to decide which icon to use here... 
+        custom_icon = 'OBJECT_DATAMODE' # Make sure your code supports all 3 layout types 
+        if self.layout_type in {'DEFAULT', 'COMPACT'}: 
+            layout.label(text=item.name, icon = custom_icon) 
+        elif self.layout_type in {'GRID'}: 
+            layout.alignment = 'CENTER' 
+            layout.label(text="", icon = custom_icon)
+
+
+class LIST_OT_NewXrTrackable(bpy.types.Operator): 
+    bl_idname = "xr_trackables.new_item" 
+    bl_label = "Add XR trackable"
+
+    def execute(self, context): 
+        context.scene.xr_trackables.add()
+        return{'FINISHED'}
+
+
+class LIST_OT_DeleteXrTrackable(bpy.types.Operator):
+    bl_idname = "xr_trackables.delete_item"
+    bl_label = "Delete XR trackable"
+
+    @classmethod
+    def poll(cls, context):
+        return context.scene.xr_trackables
+
+    def execute(self, context):
+        xr_trackables = context.scene.xr_trackables
+        idx = context.scene.xr_trackable_idx
+        xr_trackables.remove(idx)
+        context.scene.xr_trackable_idx = min(max(0, idx-1), len(xr_trackables)-1)
+        return{'FINISHED'}
+
+
+class XR_OT_set_trackable_type(bpy.types.Operator):
+    bl_idname = "xr_trackable.set_type"
+    bl_label = "Set trackable type"
+    bl_description = "Set type for the selected trackable"
+    type: bpy.props.EnumProperty(items=XR_TRACKABLE_TYPES)
+
+    def execute(self, context):
+        scene = context.scene
+        idx = context.scene.xr_trackable_idx
+        trackable = context.scene.xr_trackables[idx]
+        if trackable is None:
+            self.report({'WARNING'}, "No active object selected.")
+            return {'CANCELLED'}
+        
+        trackable.type = self.type
+        return {'FINISHED'}
+    
+    """
+class LIST_OT_MoveXrTrackable(bpy.types.Operator): 
+    bl_idname = "xr_trackables.move_item" 
+    bl_label = "Move XR trackable" 
+    direction: bpy.props.EnumProperty(items=(('UP', 'Up', ""), ('DOWN', 'Down', ""),)) 
+    
+    @classmethod 
+    def poll(cls, context): 
+        return context.scene.xr_trackables 
+    
+    def move_index(self): 
+        index = bpy.context.scene.xr_trackable_idx 
+        list_length = len(bpy.context.scene.xr_trackables) - 1 # (index starts at 0) 
+        new_index = index + (-1 if self.direction == 'UP' else 1) 
+        bpy.context.scene.xr_trackable_idx = max(0, min(new_index, list_length)) 
+        
+    def execute(self, context): 
+        xr_trackables = context.scene.xr_trackables 
+        index = context.scene.xr_trackable_idx 
+        neighbor = index + (-1 if self.direction == 'UP' else 1) 
+        xr_trackables.move(neighbor, index) 
+        self.move_index() 
+        return{'FINISHED'}
+    """
+
+
+################################################################################################
+
+class XR_ANCHOR_UL_List(bpy.types.UIList): 
+    
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index): 
+        # We could write some code to decide which icon to use here... 
+        custom_icon = 'OBJECT_DATAMODE' # Make sure your code supports all 3 layout types 
+        if self.layout_type in {'DEFAULT', 'COMPACT'}: 
+            layout.label(text=item.name, icon = custom_icon) 
+        elif self.layout_type in {'GRID'}: 
+            layout.alignment = 'CENTER' 
+            layout.label(text="", icon = custom_icon)
+
+
+
+class LIST_OT_NewXrAnchor(bpy.types.Operator): 
+    bl_idname = "xr_anchors.new_item" 
+    bl_label = "Add XR anchor"
+
+    def execute(self, context): 
+        context.scene.xr_anchors.add()
+        return{'FINISHED'}
+
+
+class LIST_OT_DeleteXrAnchor(bpy.types.Operator):
+    bl_idname = "xr_anchors.delete_item"
+    bl_label = "Delete XR anchor"
+
+    @classmethod
+    def poll(cls, context):
+        return context.scene.xr_anchors
+
+    def execute(self, context):
+        xr_anchors = context.scene.xr_anchors
+        idx = context.scene.xr_anchor_idx
+        xr_anchors.remove(idx)
+        context.scene.xr_anchor_idx = min(max(0, idx-1), len(xr_anchors)-1)
+        return{'FINISHED'}
+        
+
+class RTXR_PT_anchors_panel(bpy.types.Panel):
+    """
+    Show all anchors. In 3D View, Press N to toggle tabs overlay (top right corner).
+    """
+    bl_label = "XR Anchors"
+    bl_idname = "RTXR_PT_anchors_panel"
+    bl_category = "XR Anchors"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    #  ('DEFAULT_CLOSED', 'HIDE_HEADER', 'INSTANCED', 'HEADER_LAYOUT_EXPAND')
+    bl_options = {"DEFAULT_CLOSED"}
+
+    def draw(self, context):
+        layout = self.layout 
+        scene = context.scene 
+        
+        row = layout.row()         
+        row.label(text="Scene TRACKABLES:")
+        row = layout.row() 
+        row.template_list("XR_TRACKABLE_UL_List", "XR_trackables_list", scene, "xr_trackables", scene, "xr_trackable_idx") 
+        row = layout.row() 
+        row.operator('xr_trackables.new_item', text='NEW') 
+        row.operator('xr_trackables.delete_item', text='REMOVE') 
+        # row.operator('xr_trackables.move_item', text='UP').direction = 'UP' 
+        # row.operator('xr_trackables.move_item', text='DOWN').direction = 'DOWN' 
+        
+        if scene.xr_trackable_idx >= 0 and scene.xr_trackables: 
+            active_trackable = scene.xr_trackables[scene.xr_trackable_idx] 
+            row = layout.row()
+            row.operator_menu_enum("xr_trackable.set_type", "type", text=active_trackable.type)
+            if active_trackable.type == 'TRACKABLE_FLOOR':
+                pass
+            elif active_trackable.type == 'TRACKABLE_VIEWER':
+                pass
+            elif active_trackable.type == 'TRACKABLE_CONTROLLER':
+                row = layout.row()
+                row.prop(active_trackable, "path") 
+            elif active_trackable.type == 'TRACKABLE_PLANE':
+                row = layout.row()
+                row.prop(active_trackable, "geometricConstraint") 
+            elif active_trackable.type == 'TRACKABLE_MARKER_2D':
+                row = layout.row()
+                row.prop(active_trackable, "name") 
+                row = layout.row()
+                row.prop(active_trackable, "marker_2D")
+                # row.template_ID(active_trackable, "marker_2D", new="image.new", open="image.open")
+            elif active_trackable.type == 'TRACKABLE_MARKER_GEO':
+                row = layout.row()
+                row.prop(active_trackable, "name") 
+                row = layout.row()
+                row.prop(active_trackable, "coordinates")
+            else:
+                row = layout.row()
+                row.label(text="request this feature on github")
+
+        row = layout.row()         
+        row.label(text="Scene ANCHOR:")
+        row = layout.row() 
+        row.template_list("XR_ANCHOR_UL_List", "XR_anchors_list", scene, "xr_anchors", scene, "xr_anchor_idx") 
+        row = layout.row() 
+        row.operator('xr_anchors.new_item', text='NEW') 
+        row.operator('xr_anchors.delete_item', text='REMOVE') 
+        # row.operator('xr_anchors.move_item', text='UP').direction = 'UP' 
+        # row.operator('xr_anchors.move_item', text='DOWN').direction = 'DOWN' 
+        
+        if scene.xr_anchor_idx >= 0 and scene.xr_anchors: 
+            active_anchor = scene.xr_anchors[scene.xr_anchor_idx] 
+            row = layout.row()
+            row.prop(active_anchor, 'name')
+            row = layout.row()
+            row.prop_search(active_anchor, 'trackable_name', scene, 'xr_trackables', icon='OBJECT_DATA')
+            row = layout.row()
+            row.label(text=active_anchor.trackable_name)
+            row = layout.row()
+            row.label(text=active_anchor.trackable.name)
+            row = layout.row()
+            row.prop(active_anchor, 'requiresAnchoring')
+            row = layout.row()
+            row.prop(active_anchor, 'minimumRequiredSpace')
+            row = layout.row()
+            row.prop(active_anchor, 'aligned')
+
+
+################################################################################################
+# Node anchor selection
+################################################################################################
+
+    """
+class OBJECT_OT_set_xr_anchor_type(bpy.types.Operator):
+    bl_idname = "object.set_xr_anchor_type"
+    bl_label = "Set Anchoring Type"
+    bl_description = "Set the anchoring type for the selected object"
+
+    anchor_type: bpy.props.EnumProperty(items=XR_TRACKABLE_TYPES)
+
+    def execute(self, context):
+        obj = context.object
+        if obj is None:
+            self.report({'WARNING'}, "No active object selected.")
+            return {'CANCELLED'}
+        
+        obj.xr_anchor.anchor_type = self.anchor_type
+        return {'FINISHED'}
+    """
+
+
+    """
+class OBJECT_PT_xr_anchor_panel(bpy.types.Panel):
+    bl_label = "XR anchoring"
+    bl_idname = "OBJECT_PT_xr_anchor_panel"
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = 'object'
+
+    def draw(self, context):
+        layout = self.layout
+        obj = context.object
+        if obj is None:
+            layout.label(text="No active object selected.")
+        else:
+            xr_anchor = obj.xr_anchor # get('anchor_type', 'NONE')
+            row = layout.row()
+            row.operator_menu_enum("object.set_xr_anchor_type", "anchor_type", text=xr_anchor.anchor_type)
+
+            anchor_row = layout.row()
+            anchor_row.label(text='not available')
+
+            if xr_anchor.anchor_type == '2D_MARKER':
+                layout.template_ID(obj.xr_anchor, "marker_2D", new="image.new", open="image.open")
+    """
+
+
+def register_xr_anchors():
+    # Scene level ANCHOR def 
+    bpy.utils.register_class(XRTrackableObjectProperty)
+    bpy.types.Scene.xr_trackables = bpy.props.CollectionProperty(type=XRTrackableObjectProperty)
+    bpy.types.Scene.xr_trackable_idx = bpy.props.IntProperty(name = "Selected trackable", default = 0)
+    bpy.utils.register_class(XR_TRACKABLE_UL_List) 
+    bpy.utils.register_class(LIST_OT_NewXrTrackable) 
+    bpy.utils.register_class(LIST_OT_DeleteXrTrackable) 
+    # bpy.utils.register_class(LIST_OT_MoveXrTrackable)
+    bpy.utils.register_class(XR_OT_set_trackable_type)
+
+    # Scene level ANCHOR def 
+    bpy.utils.register_class(XRAnchorObjectProperties)
+    bpy.types.Scene.xr_anchors = bpy.props.CollectionProperty(type=XRAnchorObjectProperties)
+    bpy.types.Scene.xr_anchor_idx = bpy.props.IntProperty(name = "Selected anchor", default = 0)
+    bpy.utils.register_class(XR_ANCHOR_UL_List) 
+    bpy.utils.register_class(LIST_OT_NewXrAnchor) 
+    bpy.utils.register_class(LIST_OT_DeleteXrAnchor) 
+    # bpy.utils.register_class(LIST_OT_MoveXrAnchor)
+
+    # Node configuration
+    # bpy.types.Object.xr_anchor = bpy.props.PointerProperty(type=XRAnchorObjectProperties)
+    # bpy.utils.register_class(OBJECT_OT_set_xr_anchor_type)
+    # bpy.utils.register_class(OBJECT_PT_xr_anchor_panel)
+
+    # Scene configuration
+    bpy.utils.register_class(RTXR_PT_anchors_panel)
+
+
+def unregister_xr_anchors():
+    bpy.utils.unregister_class(RTXR_PT_anchors_panel)
+    # Scene level anchor def
+    bpy.utils.unregister_class(LIST_OT_NewXrTrackable) 
+    bpy.utils.unregister_class(LIST_OT_DeleteXrTrackable) 
+    # bpy.utils.unregister_class(LIST_OT_MoveXrTrackable)
+    bpy.utils.unregister_class(XR_OT_set_trackable_type)
+    bpy.utils.unregister_class(XR_TRACKABLE_UL_List)    
+    del bpy.types.Scene.xr_trackables
+    del bpy.types.Scene.xr_trackable_idx
+
+    bpy.utils.unregister_class(LIST_OT_NewXrAnchor) 
+    bpy.utils.unregister_class(LIST_OT_DeleteXrAnchor) 
+    # bpy.utils.unregister_class(LIST_OT_MoveXrAnchor)
+    bpy.utils.unregister_class(XR_ANCHOR_UL_List) 
+    del bpy.types.Scene.xr_anchors
+    del bpy.types.Scene.xr_anchor_idx
+    # Node level anchor ref
+    # bpy.utils.unregister_class(OBJECT_OT_set_xr_anchor_type)
+    # bpy.utils.unregister_class(OBJECT_PT_xr_anchor_panel)
+    # del bpy.types.Object.xr_anchor
+    # Anchor model 
+    bpy.utils.unregister_class(XRAnchorObjectProperties)
+    bpy.utils.unregister_class(XRTrackableObjectProperty)

--- a/addons/io_scene_gltf2_mpeg/blender/ui/markers.py
+++ b/addons/io_scene_gltf2_mpeg/blender/ui/markers.py
@@ -1,0 +1,171 @@
+from enum import StrEnum
+import logging
+import bpy
+
+
+class XRMarkerType(StrEnum):
+    MARKER_2D = 'MARKER_2D'
+    MARKER_3D = 'MARKER_3D'
+
+
+class XRMarkerFactory:
+
+    @staticmethod
+    def create_xr_marker_2d(image:bpy.types.Image):
+        marker_id = image.name
+        if XRMarkerFactory.get(marker_id) != None:
+            logging.warning(f'XR marker already exists with image {marker_id}. Don\'t duplicate anchors. Use a parent node as the root for the anchor instead.')
+            return
+        # Create a plane
+        bpy.ops.mesh.primitive_plane_add(size=1, enter_editmode=False, location=(0, 0, 0))
+        plane = bpy.context.active_object
+        plane.name = marker_id
+        plane.xr_marker.enabled = True
+        plane.xr_marker.type = XRMarkerType.MARKER_2D
+        plane.xr_marker.name = marker_id
+
+        # Create a new material
+        mat = bpy.data.materials.new(name="XRMarkerMaterial")
+        mat.use_nodes = True
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+
+        # Add texture node and link image
+        tex_image_node = mat.node_tree.nodes.new("ShaderNodeTexImage")
+        tex_image_node.image = image
+        mat.node_tree.links.new(bsdf.inputs['Base Color'], tex_image_node.outputs['Color'])
+
+        # Assign the material to the plane
+        if plane.data.materials:
+            plane.data.materials[0] = mat
+        else:
+            plane.data.materials.append(mat)
+
+        return plane
+
+    @staticmethod
+    def iter_xr_marker_objects():
+        for obj in bpy.context.scene.objects:
+            if (obj.type == 'MESH' and obj.xr_marker.enabled):
+                yield obj
+
+    @staticmethod
+    def scene_has_markers():
+        for _ in XRMarkerFactory.iter_xr_marker_objects():
+            return True
+        return False
+
+    @staticmethod
+    def list_all():
+        return [*XRMarkerFactory.iter_xr_marker_objects()]
+
+    @staticmethod
+    def name_all():
+        return [obj.xr_marker.name for obj in XRMarkerFactory.iter_xr_marker_objects()]
+        
+    @staticmethod
+    def get(marker_id):
+        for obj in XRMarkerFactory.iter_xr_marker_objects():
+            if obj.xr_marker.name == marker_id:
+                return obj
+
+
+class XRMarkerProperties(bpy.types.PropertyGroup):
+    # it's not possible to store a reference to a native blender object, 
+    # the only way is to reference objects by names, which users may update and break
+    enabled: bpy.props.BoolProperty()
+    type: bpy.props.StringProperty()
+    name: bpy.props.StringProperty()
+
+    def __str__(self):
+        return f'{self.type} - {self.name}' if self.enabled else 'diasbled'
+
+
+class XRMarkersPanelProperties(bpy.types.PropertyGroup):
+    image: bpy.props.PointerProperty(type=bpy.types.Image)
+
+
+class XRMarker2dPanel(bpy.types.Panel):
+    bl_label = "Image Markers"
+    bl_idname = "VIEW3D_PT_XrMarker2d"
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = "XR Anchoring"
+
+    def draw(self, context):
+        layout = self.layout
+        props = context.scene.xr_markers_panel
+        markers = XRMarkerFactory.list_all()
+
+        layout.label(text="Select image:")
+        layout.template_ID(props, "image", open="image.open")
+
+        if props.image:
+            exists = False
+            for m in markers:
+                if m.name == props.image.name:
+                    exists = True
+                    continue
+            if not exists:
+                layout.operator("xr_markers.create_marker", text="Create marker node")
+
+        layout.separator()
+        for obj in markers:
+            row = layout.row()
+            row.label(text=obj.xr_marker.name)
+            row.operator("xr_markers.set_active_selection", icon='SELECT_SET').marker_id = obj.xr_marker.name
+
+
+class XRMarker_OT_Create(bpy.types.Operator):
+    bl_idname = "xr_markers.create_marker"
+    bl_label = "Create marker node"
+    bl_description = "Create a marker using the selected image"
+
+    def execute(self, context):
+        props = context.scene.xr_markers_panel
+        image = props.image
+        if not image:
+            self.report({'WARNING'}, "No image selected")
+            return {'CANCELLED'}
+        obj = XRMarkerFactory.create_xr_marker_2d(image)
+        if obj:
+            self.report({'INFO'}, f"XR Marker '{obj.name}' created.")
+        return {'FINISHED'}
+
+
+class XRMarkersSetActiveSelectionOperator(bpy.types.Operator):
+    bl_idname = "xr_markers.set_active_selection"
+    bl_label = ""
+    bl_description = "Set active selection to this marker node"
+    marker_id: bpy.props.StringProperty()
+
+    def execute(self, context):
+        obj = XRMarkerFactory.get(self.marker_id)
+        if obj:
+            bpy.context.view_layer.objects.active = obj
+            bpy.ops.object.select_all(action='DESELECT')
+            obj.select_set(True)
+        else:
+            print("No valid object selected")
+        return {'FINISHED'}
+
+
+classes = [
+    XRMarkerProperties,
+    XRMarkersPanelProperties,
+    XRMarker2dPanel,
+    XRMarker_OT_Create,
+    XRMarkersSetActiveSelectionOperator
+]
+
+def register_markers():
+    for cls in classes:
+        bpy.utils.register_class(cls)
+    bpy.types.Object.xr_marker = bpy.props.PointerProperty(type=XRMarkerProperties)
+    bpy.types.Scene.xr_markers_panel = bpy.props.PointerProperty(type=XRMarkersPanelProperties)
+
+def unregister_markers():
+    del bpy.types.Scene.xr_markers_panel
+    del bpy.types.Object.xr_marker
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
+

--- a/addons/io_scene_gltf2_mpeg/exp/mpeg_anchor.py
+++ b/addons/io_scene_gltf2_mpeg/exp/mpeg_anchor.py
@@ -14,13 +14,13 @@ def _get_trackable_dict(blender_node):
     elif xr_anchor.trackable_type == "TRACKABLE_MARKER_GEO":
         r["coordinates"] = [*xr_anchor.trackable_marker_geo]
     elif xr_anchor.trackable_type == "TRACKABLE_MARKER_2D":
-        # TODO: get the IDX of the node using this marker image
-        # r["markerNode"] = -1
-        pass
+        r["markerNode"] = xr_anchor.trackable_marker_node
     elif xr_anchor.trackable_type == "TRACKABLE_MARKER_3D":
-        pass
+        r["markerNode"] = xr_anchor.trackable_marker_3d
+    elif xr_anchor.trackable_type == "TRACKABLE_CONTROLLER":
+        r["path"] = xr_anchor.trackable_controller
     elif xr_anchor.trackable_type == "TRACKABLE_APPLICATION":
-        pass
+        r["id"] = xr_anchor.trackable_id
     return r
 
 def _get_anchor_dict(trackable_ext, blender_node):
@@ -50,10 +50,8 @@ class AnchorRegistry:
     trackable_viewer = None
     trackable_plane = {}
     trackable_controller = {}
-
-    # internal
-    marker_images = {}
-
+    trackable_marker_node = {}
+        
     @classmethod
     def _get_trackable_ext(cls, blender_node):
         xr_anchor = blender_node.xr_anchor
@@ -97,6 +95,16 @@ class AnchorRegistry:
                     extension=_get_trackable_dict(blender_node)
                 )
             trackable_ext = cls.trackable_controller[path]
+
+        if trackable_type == "TRACKABLE_MARKER_2D":
+            markerNode = xr_anchor.trackable_marker_node
+            if not (markerNode in cls.trackable_marker_node):
+                cls.trackable_marker_node[markerNode] = gltf2_io_extensions.ChildOfRootExtension(
+                    name="MPEG_anchor",
+                    path=["trackables"],
+                    extension=_get_trackable_dict(blender_node)
+                )
+            trackable_ext = cls.trackable_marker_node[markerNode]
 
         else:
             trackable_ext = gltf2_io_extensions.ChildOfRootExtension(

--- a/addons/io_scene_gltf2_mpeg/exp/mpeg_anchor.py
+++ b/addons/io_scene_gltf2_mpeg/exp/mpeg_anchor.py
@@ -19,7 +19,7 @@ def _get_trackable_dict(blender_node):
         r["geometricConstraint"] = 0 if xr_anchor.trackable_plane == 'HORIZONTAL_PLANE' else 1
     elif xr_anchor.trackable_type == "TRACKABLE_MARKER_2D":
         r["type"] = 4
-        r["markerNode"] = xr_anchor.trackable_marker_node
+        r["markerNode"] = xr_anchor.trackable_marker_node_name
     elif xr_anchor.trackable_type == "TRACKABLE_MARKER_3D":
         r["type"] = 5
         r["markerNode"] = xr_anchor.trackable_marker_3d
@@ -53,7 +53,7 @@ class AnchorRegistry:
     trackables = []
     anchors = []
 
-    # de-duplicate trrackables
+    # de-duplicate trackables
     trackable_floor = None
     trackable_viewer = None
     trackable_plane = {}
@@ -86,33 +86,36 @@ class AnchorRegistry:
 
         elif trackable_type == "TRACKABLE_PLANE":
             constraint = xr_anchor.trackable_plane
-            if not (constraint in cls.trackable_plane):
+            if constraint in cls.trackable_plane:
+                trackable_ext = cls.trackable_plane[constraint]
+            else:
                 cls.trackable_plane[constraint] = gltf2_io_extensions.ChildOfRootExtension(
                     name="MPEG_anchor",
                     path=["trackables"],
                     extension=_get_trackable_dict(blender_node)
                 )
-            trackable_ext = cls.trackable_plane[constraint]
 
         elif trackable_type == "TRACKABLE_CONTROLLER":
             path = xr_anchor.trackable_controller
-            if not (path in cls.trackable_plane):
+            if path in cls.trackable_plane:
+                trackable_ext = cls.trackable_controller[path]
+            else:
                 cls.trackable_controller[path] = gltf2_io_extensions.ChildOfRootExtension(
-                    name="MPEG_anchor",
-                    path=["trackables"],
-                    extension=_get_trackable_dict(blender_node)
-                )
-            trackable_ext = cls.trackable_controller[path]
-
+                        name="MPEG_anchor",
+                        path=["trackables"],
+                        extension=_get_trackable_dict(blender_node)
+                    )
+    
         if trackable_type == "TRACKABLE_MARKER_2D":
-            markerNode = xr_anchor.trackable_marker_node
-            if not (markerNode in cls.trackable_marker_node):
-                cls.trackable_marker_node[markerNode] = gltf2_io_extensions.ChildOfRootExtension(
+            marker_node_name = xr_anchor.trackable_marker_node_name
+            if marker_node_name in cls.trackable_marker_node:
+                trackable_ext = cls.trackable_marker_node[marker_node_name]
+            else:
+                cls.trackable_marker_node[marker_node_name] = gltf2_io_extensions.ChildOfRootExtension(
                     name="MPEG_anchor",
                     path=["trackables"],
                     extension=_get_trackable_dict(blender_node)
                 )
-            trackable_ext = cls.trackable_marker_node[markerNode]
 
         else:
             trackable_ext = gltf2_io_extensions.ChildOfRootExtension(
@@ -126,8 +129,11 @@ class AnchorRegistry:
 
     @classmethod
     def get_node_anchor_extension(cls, blender_node):
-
-        trackable_ext = cls._get_trackable_ext(blender_node)
+        trackable_ext = gltf2_io_extensions.ChildOfRootExtension(
+                    name="MPEG_anchor",
+                    path=["trackables"],
+                    extension=_get_trackable_dict(blender_node)
+                )
         
         anchor_ext = gltf2_io_extensions.ChildOfRootExtension(
             name="MPEG_anchor",

--- a/addons/io_scene_gltf2_mpeg/exp/mpeg_anchor.py
+++ b/addons/io_scene_gltf2_mpeg/exp/mpeg_anchor.py
@@ -1,0 +1,127 @@
+import bpy
+from io_scene_gltf2.io.com import gltf2_io, gltf2_io_extensions
+
+MPEG_ANCHOR = "MPEG_anchor"
+
+
+def _get_trackable_dict(blender_node):
+    xr_anchor = blender_node.xr_anchor
+    r = {
+        "type": xr_anchor.trackable_type
+    }
+    if xr_anchor.trackable_type == "TRACKABLE_PLANE":
+        r["geometricConstraint"] = 0 if xr_anchor.trackable_plane == 'HORIZONTAL_PLANE' else 1
+    elif xr_anchor.trackable_type == "TRACKABLE_MARKER_GEO":
+        r["coordinates"] = [*xr_anchor.trackable_marker_geo]
+    elif xr_anchor.trackable_type == "TRACKABLE_MARKER_2D":
+        # TODO: get the IDX of the node using this marker image
+        # r["markerNode"] = -1
+        pass
+    elif xr_anchor.trackable_type == "TRACKABLE_MARKER_3D":
+        pass
+    elif xr_anchor.trackable_type == "TRACKABLE_APPLICATION":
+        pass
+    return r
+
+def _get_anchor_dict(trackable_ext, blender_node):
+    xr_anchor = blender_node.xr_anchor
+    r = {
+        "trackable": trackable_ext,
+        "requiresAnchoring": xr_anchor.requiresAnchoring
+    }
+    if sum(xr_anchor.minimumRequiredSpace) > 0.0:
+        r["minimumRequiredSpace"] = [*xr_anchor.minimumRequiredSpace]
+    if xr_anchor.aligned == 'ALIGNED_NOTSCALED': 
+        r["aligned"] = 1
+    elif xr_anchor.aligned == 'ALIGNED_SCALED': 
+        r["aligned"] = 2
+    # OPTIONAL, not yet implemented in player:
+    # - actions
+    # - light
+    return r
+
+class AnchorRegistry:
+
+    trackables = []
+    anchors = []
+
+    # de-duplicate trrackables
+    trackable_floor = None
+    trackable_viewer = None
+    trackable_plane = {}
+    trackable_controller = {}
+
+    # internal
+    marker_images = {}
+
+    @classmethod
+    def _get_trackable_ext(cls, blender_node):
+        xr_anchor = blender_node.xr_anchor
+        trackable_type = xr_anchor.trackable_type
+        trackable_ext = None
+
+        if trackable_type == "TRACKABLE_FLOOR":
+            if cls.trackable_floor is None:
+                cls.trackable_floor = gltf2_io_extensions.ChildOfRootExtension(
+                    name="MPEG_anchor",
+                    path=["trackables"],
+                    extension=_get_trackable_dict(blender_node)
+                )
+            trackable_ext = cls.trackable_floor
+        
+        elif trackable_type == "TRACKABLE_VIEWER":
+            if cls.trackable_viewer is None:
+                cls.trackable_viewer = gltf2_io_extensions.ChildOfRootExtension(
+                    name="MPEG_anchor",
+                    path=["trackables"],
+                    extension=_get_trackable_dict(blender_node)
+                )
+            trackable_ext = cls.trackable_viewer
+
+        elif trackable_type == "TRACKABLE_PLANE":
+            constraint = xr_anchor.trackable_plane
+            if not (constraint in cls.trackable_plane):
+                cls.trackable_plane[constraint] = gltf2_io_extensions.ChildOfRootExtension(
+                    name="MPEG_anchor",
+                    path=["trackables"],
+                    extension=_get_trackable_dict(blender_node)
+                )
+            trackable_ext = cls.trackable_plane[constraint]
+
+        elif trackable_type == "TRACKABLE_CONTROLLER":
+            path = xr_anchor.trackable_controller
+            if not (path in cls.trackable_plane):
+                cls.trackable_controller[path] = gltf2_io_extensions.ChildOfRootExtension(
+                    name="MPEG_anchor",
+                    path=["trackables"],
+                    extension=_get_trackable_dict(blender_node)
+                )
+            trackable_ext = cls.trackable_controller[path]
+
+        else:
+            trackable_ext = gltf2_io_extensions.ChildOfRootExtension(
+                    name="MPEG_anchor",
+                    path=["trackables"],
+                    extension=_get_trackable_dict(blender_node)
+                )
+        
+        return trackable_ext 
+
+
+    @classmethod
+    def get_node_anchor_extension(cls, blender_node):
+
+        trackable_ext = cls._get_trackable_ext(blender_node)
+        
+        anchor_ext = gltf2_io_extensions.ChildOfRootExtension(
+            name="MPEG_anchor",
+            path=["anchors"],
+            extension=_get_anchor_dict(trackable_ext, blender_node)
+        )
+        
+        return gltf2_io_extensions.Extension(
+                name=MPEG_ANCHOR,
+                extension={
+                    "anchor": anchor_ext
+                }
+        )

--- a/addons/io_scene_gltf2_mpeg/exp/mpeg_anchor.py
+++ b/addons/io_scene_gltf2_mpeg/exp/mpeg_anchor.py
@@ -6,20 +6,28 @@ MPEG_ANCHOR = "MPEG_anchor"
 
 def _get_trackable_dict(blender_node):
     xr_anchor = blender_node.xr_anchor
-    r = {
-        "type": xr_anchor.trackable_type
-    }
-    if xr_anchor.trackable_type == "TRACKABLE_PLANE":
+    r = {}
+    if xr_anchor.trackable_type == "TRACKABLE_FLOOR":
+        r["type"] = 0
+    elif xr_anchor.trackable_type == "TRACKABLE_VIEWER":
+        r["type"] = 1
+    elif xr_anchor.trackable_type == "TRACKABLE_CONTROLLER":
+        r["type"] = 2
+        r["path"] = xr_anchor.trackable_controller
+    elif xr_anchor.trackable_type == "TRACKABLE_PLANE":
+        r["type"] = 3
         r["geometricConstraint"] = 0 if xr_anchor.trackable_plane == 'HORIZONTAL_PLANE' else 1
-    elif xr_anchor.trackable_type == "TRACKABLE_MARKER_GEO":
-        r["coordinates"] = [*xr_anchor.trackable_marker_geo]
     elif xr_anchor.trackable_type == "TRACKABLE_MARKER_2D":
+        r["type"] = 4
         r["markerNode"] = xr_anchor.trackable_marker_node
     elif xr_anchor.trackable_type == "TRACKABLE_MARKER_3D":
+        r["type"] = 5
         r["markerNode"] = xr_anchor.trackable_marker_3d
-    elif xr_anchor.trackable_type == "TRACKABLE_CONTROLLER":
-        r["path"] = xr_anchor.trackable_controller
+    elif xr_anchor.trackable_type == "TRACKABLE_MARKER_GEO":
+        r["type"] = 6
+        r["coordinates"] = [*xr_anchor.trackable_marker_geo]
     elif xr_anchor.trackable_type == "TRACKABLE_APPLICATION":
+        r["type"] = 7
         r["id"] = xr_anchor.trackable_id
     return r
 

--- a/addons/io_scene_gltf2_mpeg/exp/mpeg_export.py
+++ b/addons/io_scene_gltf2_mpeg/exp/mpeg_export.py
@@ -85,7 +85,7 @@ def _fix_anchoring_marker_nodes(gltf2_object, export_settings):
                 t["markerNode"] = i
         # marker nodes can't have parents
         for n in gltf2_object.nodes:
-            n.children = [i for i in n.children if not i in marker_nodes_i]
+            n.children = [i for i in n.children if i not in marker_nodes_i]
         # prevent marker node instantiation
         for s in gltf2_object.scenes:
-            s.nodes = [i for i in s.nodes if not i in marker_nodes_i]
+            s.nodes = [i for i in s.nodes if i not in marker_nodes_i]

--- a/addons/io_scene_gltf2_mpeg/exp/mpeg_export.py
+++ b/addons/io_scene_gltf2_mpeg/exp/mpeg_export.py
@@ -12,6 +12,7 @@ import bpy
 
 from .mpeg_video_texture import get_video_texture_extension
 from .mpeg_audio_source import get_audio_source_extension
+from .mpeg_anchor import AnchorRegistry
 from .mpeg_media import MediaLibrary
 
 class glTF2ExportMpegExtension:
@@ -27,6 +28,11 @@ class glTF2ExportMpegExtension:
                 return
             _add_gltf_extension(gltf2_object, ext)
             self.audio_source_id += 1
+        if blender_node.xr_anchor.enabled:
+            ext = AnchorRegistry.get_node_anchor_extension(blender_node)
+            if ext is None:
+                return
+            _add_gltf_extension(gltf2_object, ext)
 
     def gather_texture_hook(self, texture, blender_shader_sockets, export_settings):
         if not self.enabled:

--- a/addons/io_scene_gltf2_mpeg/exp/mpeg_export.py
+++ b/addons/io_scene_gltf2_mpeg/exp/mpeg_export.py
@@ -52,7 +52,6 @@ class glTF2ExportMpegExtension:
                 except BaseException as e:
                     print(e)
             _fix_up_buffer_references(gltf2_object, export_settings)
-        if not export_settings.get("mpeg_anchor_debug"):
             _fix_anchoring_marker_nodes(gltf2_object, export_settings)
     
 
@@ -84,9 +83,9 @@ def _fix_anchoring_marker_nodes(gltf2_object, export_settings):
                 i = node_name_i_map[marker_node_name]
                 marker_nodes_i.add(i)
                 t["markerNode"] = i
-        # prevent marker node instantiation
-        for s in gltf2_object.scenes:
-            s.nodes = [i for i in s.nodes if not i in marker_nodes_i]
         # marker nodes can't have parents
         for n in gltf2_object.nodes:
             n.children = [i for i in n.children if not i in marker_nodes_i]
+        # prevent marker node instantiation
+        for s in gltf2_object.scenes:
+            s.nodes = [i for i in s.nodes if not i in marker_nodes_i]


### PR DESCRIPTION
Initial support for defining XR anchors based on the `MPEG_anchor` gltf extension , the following anchor types are implemented:
- TRACKABLE_FLOOR
- TRACKABLE_VIEWER
- TRACKABLE_CONTROLLER
- TRACKABLE_PLANE
- TRACKABLE_MARKER_2D
- TRACKABLE_MARKER_GEO
- TRACKABLE_APPLICATION

The following is not implemented, as not currently supported by the unity player:
- TRACKABLE_MARKER_3D

Fixes #9 